### PR TITLE
feat: implementar HU-PAG-01 (iniciar transaccion de pago)

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_crear_modulo_pagos.py
+++ b/alembic/versions/a1b2c3d4e5f6_crear_modulo_pagos.py
@@ -1,7 +1,7 @@
 """crear_modulo_pagos
 
 Revision ID: a1b2c3d4e5f6
-Revises: 346ae1b3d9a2
+Revises: d4e5f6a7b8c9
 Create Date: 2026-05-30 10:00:00.000000
 
 """
@@ -26,9 +26,9 @@ def upgrade() -> None:
     sa.Column('referencia_interna', sa.String(length=100), nullable=False),
     sa.Column('id_transaccion_wompi', sa.String(length=100), nullable=True),
     sa.Column('monto_en_centavos', sa.BigInteger(), nullable=False),
-    sa.Column('moneda', sa.String(length=10), nullable=False),
+    sa.Column('moneda', sa.String(length=10), nullable=False, server_default='COP'),
     sa.Column('metodo_pago', sa.String(length=50), nullable=True),
-    sa.Column('estado_transaccion', sa.String(length=20), nullable=False),
+    sa.Column('estado_transaccion', sa.String(length=20), nullable=False, server_default='PENDING'),
     sa.Column('url_checkout', sa.Text(), nullable=True),
     sa.Column('fecha_creacion', sa.DateTime(timezone=True), nullable=False),
     sa.Column('fecha_actualizacion', sa.DateTime(timezone=True), nullable=False),

--- a/alembic/versions/fb020c36edce_hu_auth_02_politica_contrasenas_admin.py
+++ b/alembic/versions/fb020c36edce_hu_auth_02_politica_contrasenas_admin.py
@@ -1,7 +1,7 @@
 """HU-AUTH-02-politica-contrasenas-admin
 
 Revision ID: fb020c36edce
-Revises: 109a990046d4
+Revises: b2c3d4e5f6a7
 Create Date: 2026-05-23
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 revision: str = 'fb020c36edce'
-down_revision: Union[str, None] = '109a990046d4'
+down_revision: Union[str, None] = 'b2c3d4e5f6a7'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/app/api/pagos/__init__.py
+++ b/app/api/pagos/__init__.py
@@ -1,0 +1,8 @@
+import importlib.util, pathlib
+
+_path = pathlib.Path(__file__).parent / "pagos.api.py"
+_spec = importlib.util.spec_from_file_location("pagos_api", _path)
+_mod  = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+router = _mod.router

--- a/app/api/pagos/pagos.api.py
+++ b/app/api/pagos/pagos.api.py
@@ -1,0 +1,81 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# CAPA: API – Módulo de Pagos
+# Responsabilidad: Endpoints HTTP del módulo de pagos.
+# ─────────────────────────────────────────────────────────────────────────────
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import importlib.util, os
+from uuid import UUID
+
+from app.core.database import get_db
+
+# Cargar dependencia de autenticación
+_path_auth = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "autenticacion", "autenticacion.api.py"))
+_spec_auth = importlib.util.spec_from_file_location("autenticacion_api", _path_auth)
+_mod_auth  = importlib.util.module_from_spec(_spec_auth)
+_spec_auth.loader.exec_module(_mod_auth)
+get_usuario_actual = _mod_auth.get_usuario_actual
+
+# Cargar schemas
+_path_sch = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "domain", "pagos", "pagos.schemas.py"))
+_spec_sch = importlib.util.spec_from_file_location("pagos_schemas", _path_sch)
+_mod_sch  = importlib.util.module_from_spec(_spec_sch)
+_spec_sch.loader.exec_module(_mod_sch)
+PagoEntrada = _mod_sch.PagoEntrada
+
+# Cargar servicio
+_path_svc = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "services", "pagos", "pagos.services.py"))
+_spec_svc = importlib.util.spec_from_file_location("pagos_services", _path_svc)
+_mod_svc  = importlib.util.module_from_spec(_spec_svc)
+_spec_svc.loader.exec_module(_mod_svc)
+PagoService = _mod_svc.PagoService
+
+router = APIRouter(prefix="/pagos", tags=["Pagos"])
+
+
+@router.post("", status_code=201)
+def iniciar_pago(
+    body: PagoEntrada,
+    db: Session = Depends(get_db),
+    usuario_actual = Depends(get_usuario_actual)
+):
+    servicio = PagoService(db)
+    return servicio.iniciar_pago(
+        usuario_id=usuario_actual.id,
+        pedido_id=body.pedidoId,
+        monto_en_centavos=body.montoEnCentavos,
+        moneda=body.moneda,
+        correo_cliente=body.correoCliente,
+    )
+
+
+@router.get("/referencia/{referencia}")
+def consultar_pago_por_referencia(
+    referencia: str,
+    db: Session = Depends(get_db),
+    usuario_actual = Depends(get_usuario_actual)
+):
+    if usuario_actual.rol != "administrador":
+        raise HTTPException(status_code=403, detail={
+            "success": False, "statusCode": 403,
+            "message": "Acceso denegado",
+            "error": {"error_code": "FORBIDDEN",
+                      "details": "Solo un administrador puede acceder a este recurso."}
+        })
+    servicio = PagoService(db)
+    return servicio.consultar_por_referencia(referencia)
+
+
+@router.get("/{pago_id}")
+def consultar_pago_por_id(
+    pago_id: UUID,
+    db: Session = Depends(get_db),
+    usuario_actual = Depends(get_usuario_actual)
+):
+    servicio = PagoService(db)
+    return servicio.consultar_por_id(
+        pago_id=pago_id,
+        usuario_id=usuario_actual.id,
+        rol=usuario_actual.rol,
+    )

--- a/app/domain/pagos/pagos.schemas.py
+++ b/app/domain/pagos/pagos.schemas.py
@@ -1,0 +1,33 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# CAPA: DOMAIN – Módulo de Pagos
+# Responsabilidad: Define los schemas Pydantic v2 para validación de entrada
+# y serialización de salida del módulo de pagos.
+# ─────────────────────────────────────────────────────────────────────────────
+
+from pydantic import BaseModel, UUID4, Field
+from datetime import datetime
+from typing import Optional
+
+
+class PagoEntrada(BaseModel):
+    pedidoId:        UUID4
+    montoEnCentavos: int = Field(..., gt=0)
+    moneda:          str = Field(default="COP", max_length=10)
+    correoCliente:   str = Field(..., max_length=200)
+
+
+class PagoSalida(BaseModel):
+    id:                   UUID4
+    pedido_id:            UUID4
+    usuario_id:           UUID4
+    referencia_interna:   str
+    id_transaccion_wompi: Optional[str] = None
+    monto_en_centavos:    int
+    moneda:               str
+    metodo_pago:          Optional[str] = None
+    estado_transaccion:   str
+    url_checkout:         Optional[str] = None
+    fecha_creacion:       datetime
+    fecha_actualizacion:  datetime
+
+    model_config = {"from_attributes": True}

--- a/app/repositories/pagos/pagos.repositori.py
+++ b/app/repositories/pagos/pagos.repositori.py
@@ -1,0 +1,26 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# CAPA: REPOSITORY – Módulo de Pagos
+# Responsabilidad: Único lugar donde se ejecutan queries SQL del módulo.
+# ─────────────────────────────────────────────────────────────────────────────
+
+from sqlalchemy.orm import Session
+from app.domain.pagos import Pago
+
+
+class PagoRepositorio:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def guardar(self, pago: Pago) -> Pago:
+        self.db.add(pago)
+        self.db.flush()
+        return pago
+
+    def buscar_por_id(self, pago_id) -> Pago:
+        return self.db.query(Pago).filter(Pago.id == pago_id).first()
+
+    def buscar_por_referencia(self, referencia_interna: str) -> Pago:
+        return self.db.query(Pago).filter(Pago.referencia_interna == referencia_interna).first()
+
+    def listar_todos(self) -> list:
+        return self.db.query(Pago).order_by(Pago.fecha_creacion.desc()).all()

--- a/app/services/pagos/pagos.services.py
+++ b/app/services/pagos/pagos.services.py
@@ -1,0 +1,187 @@
+from sqlalchemy.orm import Session
+from datetime import datetime, timezone, time
+from zoneinfo import ZoneInfo
+from fastapi import HTTPException
+import importlib.util, os, uuid
+
+# Cargar repositorio de pagos
+_path_pag = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "repositories", "pagos", "pagos.repositori.py"))
+_spec_pag = importlib.util.spec_from_file_location("pagos_repositori", _path_pag)
+_mod_pag  = importlib.util.module_from_spec(_spec_pag)
+_spec_pag.loader.exec_module(_mod_pag)
+PagoRepositorio = _mod_pag.PagoRepositorio
+
+# Cargar repositorio de pedidos
+_path_ped = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "repositories", "pedidos", "pedidos.repositori.py"))
+_spec_ped = importlib.util.spec_from_file_location("pedidos_repositori", _path_ped)
+_mod_ped  = importlib.util.module_from_spec(_spec_ped)
+_spec_ped.loader.exec_module(_mod_ped)
+PedidoRepositorio = _mod_ped.PedidoRepositorio
+
+# Cargar adaptador de Wompi
+_path_wmp = os.path.abspath(os.path.join(os.path.dirname(__file__), "wompi.adapter.py"))
+_spec_wmp = importlib.util.spec_from_file_location("wompi_adapter", _path_wmp)
+_mod_wmp  = importlib.util.module_from_spec(_spec_wmp)
+_spec_wmp.loader.exec_module(_mod_wmp)
+WompiAdapter = _mod_wmp.WompiAdapter
+
+from app.domain.pagos import Pago
+
+HORA_INICIO_PERMITIDA = time(6, 0)   # 6:00 AM
+HORA_FIN_PERMITIDA    = time(23, 0)  # 11:00 PM
+ZONA_COLOMBIA         = ZoneInfo("America/Bogota")
+
+
+class PagoService:
+    def __init__(self, db: Session):
+        self.db = db
+        self.pago_repo   = PagoRepositorio(db)
+        self.pedido_repo = PedidoRepositorio(db)
+        self.wompi       = WompiAdapter()
+
+    def _validar_horario_permitido(self, ahora: datetime):
+        hora_actual = ahora.astimezone(ZONA_COLOMBIA).time()
+        if not (HORA_INICIO_PERMITIDA <= hora_actual <= HORA_FIN_PERMITIDA):
+            raise HTTPException(status_code=403, detail={
+                "success": False, "statusCode": 403,
+                "message": "El servicio de pagos no está disponible en este momento",
+                "error": {"error_code": "PAYMENT_OUTSIDE_ALLOWED_HOURS",
+                          "details": "Las transacciones solo se procesan entre las 6:00 AM y las 11:00 PM.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+    def iniciar_pago(self, usuario_id, pedido_id, monto_en_centavos: int, moneda: str, correo_cliente: str) -> dict:
+        ahora = datetime.now(timezone.utc)
+
+        pedido = self.pedido_repo.buscar_por_id(pedido_id)
+        if not pedido:
+            raise HTTPException(status_code=404, detail={
+                "success": False, "statusCode": 404,
+                "message": "Pedido no encontrado",
+                "error": {"error_code": "ORDER_NOT_FOUND",
+                          "details": "No existe un pedido con el ID proporcionado.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        if str(pedido.usuario_id) != str(usuario_id):
+            raise HTTPException(status_code=403, detail={
+                "success": False, "statusCode": 403,
+                "message": "Acceso denegado",
+                "error": {"error_code": "FORBIDDEN",
+                          "details": "El pedido indicado no pertenece al usuario autenticado.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        if pedido.estado != "pendiente":
+            raise HTTPException(status_code=409, detail={
+                "success": False, "statusCode": 409,
+                "message": "El pedido no está disponible para pago",
+                "error": {"error_code": "ORDER_NOT_PAYABLE",
+                          "details": f"Solo se pueden pagar pedidos en estado 'pendiente'. El pedido {pedido_id} está en estado '{pedido.estado}'.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        monto_esperado = round(float(pedido.total) * 100)
+        if monto_en_centavos != monto_esperado:
+            raise HTTPException(status_code=400, detail={
+                "success": False, "statusCode": 400,
+                "message": "El monto enviado no coincide con el total del pedido",
+                "error": {"error_code": "AMOUNT_MISMATCH",
+                          "details": f"El montoEnCentavos debe ser {monto_esperado} (total del pedido x 100). Se recibió {monto_en_centavos}.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        self._validar_horario_permitido(ahora)
+
+        timestamp = int(ahora.timestamp())
+        referencia_interna = f"FARMA-PED-{pedido.id}-{timestamp}"
+
+        respuesta_wompi = self.wompi.crear_transaccion(
+            monto_en_centavos=monto_en_centavos,
+            moneda=moneda,
+            referencia=referencia_interna,
+            correo_cliente=correo_cliente,
+        )
+
+        pago = Pago(
+            id=uuid.uuid4(),
+            pedido_id=pedido.id,
+            usuario_id=usuario_id,
+            referencia_interna=referencia_interna,
+            monto_en_centavos=monto_en_centavos,
+            moneda=moneda,
+            estado_transaccion=respuesta_wompi["estado"],
+            url_checkout=respuesta_wompi["urlCheckout"],
+            fecha_creacion=ahora,
+            fecha_actualizacion=ahora,
+        )
+        self.pago_repo.guardar(pago)
+        self.db.commit()
+        self.db.refresh(pago)
+
+        return {
+            "success": True,
+            "statusCode": 201,
+            "message": "Transacción iniciada correctamente, redirigir al cliente al checkout de pago.",
+            "data": {
+                "pagoId": str(pago.id),
+                "urlCheckout": pago.url_checkout,
+                "referenciaInterna": pago.referencia_interna,
+                "estadoTransaccion": pago.estado_transaccion,
+            }
+        }
+
+    def consultar_por_id(self, pago_id, usuario_id, rol: str) -> dict:
+        ahora = datetime.now(timezone.utc)
+        pago = self.pago_repo.buscar_por_id(pago_id)
+        if not pago:
+            raise HTTPException(status_code=404, detail={
+                "success": False, "statusCode": 404,
+                "message": "Pago no encontrado",
+                "error": {"error_code": "PAYMENT_NOT_FOUND",
+                          "details": "No existe un pago con el ID o referencia proporcionada.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        if rol != "administrador" and str(pago.usuario_id) != str(usuario_id):
+            raise HTTPException(status_code=403, detail={
+                "success": False, "statusCode": 403,
+                "message": "Acceso denegado",
+                "error": {"error_code": "FORBIDDEN",
+                          "details": "No tiene permisos para consultar este pago.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        return self._serializar_pago(pago, "Pago encontrado")
+
+    def consultar_por_referencia(self, referencia_interna: str) -> dict:
+        ahora = datetime.now(timezone.utc)
+        pago = self.pago_repo.buscar_por_referencia(referencia_interna)
+        if not pago:
+            raise HTTPException(status_code=404, detail={
+                "success": False, "statusCode": 404,
+                "message": "Pago no encontrado",
+                "error": {"error_code": "PAYMENT_NOT_FOUND",
+                          "details": "No existe un pago con el ID o referencia proporcionada.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        return self._serializar_pago(pago, "Pago encontrado")
+
+    def _serializar_pago(self, pago: Pago, mensaje: str) -> dict:
+        return {
+            "success": True,
+            "statusCode": 200,
+            "message": mensaje,
+            "data": {
+                "pagoId": str(pago.id),
+                "pedidoId": str(pago.pedido_id),
+                "referenciaInterna": pago.referencia_interna,
+                "idTransaccionWompi": pago.id_transaccion_wompi,
+                "montoEnCentavos": pago.monto_en_centavos,
+                "moneda": pago.moneda,
+                "metodoPago": pago.metodo_pago,
+                "estadoTransaccion": pago.estado_transaccion,
+                "fechaPago": pago.fecha_actualizacion.isoformat(),
+            }
+        }

--- a/app/services/pagos/wompi.adapter.py
+++ b/app/services/pagos/wompi.adapter.py
@@ -1,0 +1,21 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# CAPA: SERVICE – Adaptador de Wompi
+# Responsabilidad: Encapsula la integración HTTP con la pasarela de pagos Wompi.
+# Mientras no se cuente con credenciales reales, genera una URL de checkout
+# simulada para no bloquear el flujo del módulo.
+# ─────────────────────────────────────────────────────────────────────────────
+
+import os
+
+
+class WompiAdapter:
+    BASE_CHECKOUT_URL = os.getenv("WOMPI_CHECKOUT_URL", "https://checkout.wompi.co/l/")
+
+    def crear_transaccion(self, monto_en_centavos: int, moneda: str, referencia: str, correo_cliente: str) -> dict:
+        """
+        Inicia una transacción en Wompi. Retorna la urlCheckout y el estado inicial.
+        """
+        return {
+            "urlCheckout": f"{self.BASE_CHECKOUT_URL}{referencia}",
+            "estado": "PENDING",
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv==1.0.1
 alembic==1.13.1
 psycopg2-binary==2.9.12
 bcrypt==4.1.3
+tzdata==2026.2

--- a/routes.py
+++ b/routes.py
@@ -10,6 +10,7 @@ from app.api.productos import (
 )
 from app.api.carritos import router as carritos_router
 from app.api.pedidos import router as pedidos_router
+from app.api.pagos import router as pagos_router
 
 router = APIRouter(prefix="/api/v1")
 router.include_router(usuarios_router)
@@ -21,3 +22,4 @@ router.include_router(router_lotes)
 router.include_router(router_presentaciones)
 router.include_router(carritos_router)
 router.include_router(pedidos_router)
+router.include_router(pagos_router)


### PR DESCRIPTION
Agrega el flujo completo de inicio de pago: schemas, repositorio, servicio (validaciones de pedido, monto, horario en zona Colombia), adaptador Wompi simulado y endpoints REST. Corrige server_default de moneda/estado_transaccion en la migracion de pagos y enlaza la cadena de migraciones (fb020c36edce -> b2c3d4e5f6a7) para evitar multiples heads. Agrega tzdata a requirements para soporte de zoneinfo en Windows.