### PR TITLE
feat: implementar HU-PAG-02 (webhook seguro de Wompi)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,14 @@ DATABASE_URL = "sqlite:///./dev.db"
 # Seguridad
 SECRET_KEY = "cambia-este-valor-en-produccion"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
+# Wompi (sandbox)
+WOMPI_PUBLIC_KEY = "pub_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+WOMPI_PRIVATE_KEY = "prv_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+WOMPI_EVENTS_SECRET = "test_events_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+WOMPI_INTEGRITY_SECRET = "test_integrity_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# Factus (sandbox)
+FACTUS_BASE_URL = "https://api-sandbox.factus.com.co"
+FACTUS_EMAIL = "tu-correo@example.com"
+FACTUS_PASSWORD = "cambia-este-valor"
+FACTUS_CLIENT_ID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+FACTUS_CLIENT_SECRET = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/app/api/pagos/pagos.api.py
+++ b/app/api/pagos/pagos.api.py
@@ -23,6 +23,7 @@ _spec_sch = importlib.util.spec_from_file_location("pagos_schemas", _path_sch)
 _mod_sch  = importlib.util.module_from_spec(_spec_sch)
 _spec_sch.loader.exec_module(_mod_sch)
 PagoEntrada = _mod_sch.PagoEntrada
+WebhookWompiEntrada = _mod_sch.WebhookWompiEntrada
 
 # Cargar servicio
 _path_svc = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "services", "pagos", "pagos.services.py"))
@@ -48,6 +49,15 @@ def iniciar_pago(
         moneda=body.moneda,
         correo_cliente=body.correoCliente,
     )
+
+
+@router.post("/webhook")
+def procesar_webhook_wompi(
+    body: WebhookWompiEntrada,
+    db: Session = Depends(get_db),
+):
+    servicio = PagoService(db)
+    return servicio.procesar_webhook(body.model_dump())
 
 
 @router.get("/referencia/{referencia}")

--- a/app/domain/pagos/pagos.schemas.py
+++ b/app/domain/pagos/pagos.schemas.py
@@ -16,6 +16,26 @@ class PagoEntrada(BaseModel):
     correoCliente:   str = Field(..., max_length=200)
 
 
+class WompiSignature(BaseModel):
+    checksum:   str
+    properties: list[str]
+
+
+class WompiTransactionData(BaseModel):
+    id:                  str
+    reference:           str
+    status:              str
+    amount_in_cents:     int
+    currency:            str
+    payment_method_type: Optional[str] = None
+
+
+class WebhookWompiEntrada(BaseModel):
+    event:     str
+    data:      WompiTransactionData
+    signature: WompiSignature
+
+
 class PagoSalida(BaseModel):
     id:                   UUID4
     pedido_id:            UUID4

--- a/app/repositories/pagos/pagos.repositori.py
+++ b/app/repositories/pagos/pagos.repositori.py
@@ -4,6 +4,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 from sqlalchemy.orm import Session
+from datetime import datetime, timezone
 from app.domain.pagos import Pago
 
 
@@ -24,3 +25,12 @@ class PagoRepositorio:
 
     def listar_todos(self) -> list:
         return self.db.query(Pago).order_by(Pago.fecha_creacion.desc()).all()
+
+    def actualizar_desde_webhook(self, pago: Pago, estado_transaccion: str, id_transaccion_wompi: str, metodo_pago: str) -> Pago:
+        pago.estado_transaccion = estado_transaccion
+        pago.id_transaccion_wompi = id_transaccion_wompi
+        pago.metodo_pago = metodo_pago
+        pago.fecha_actualizacion = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(pago)
+        return pago

--- a/app/services/pagos/pagos.services.py
+++ b/app/services/pagos/pagos.services.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from datetime import datetime, timezone, time
 from zoneinfo import ZoneInfo
 from fastapi import HTTPException
+import hashlib
 import importlib.util, os, uuid
 
 # Cargar repositorio de pagos
@@ -30,6 +31,8 @@ from app.domain.pagos import Pago
 HORA_INICIO_PERMITIDA = time(6, 0)   # 6:00 AM
 HORA_FIN_PERMITIDA    = time(23, 0)  # 11:00 PM
 ZONA_COLOMBIA         = ZoneInfo("America/Bogota")
+
+WOMPI_EVENTS_SECRET   = os.getenv("WOMPI_EVENTS_SECRET", "")
 
 
 class PagoService:
@@ -167,6 +170,98 @@ class PagoService:
             })
 
         return self._serializar_pago(pago, "Pago encontrado")
+
+    PROPIEDADES_A_CAMPOS = {
+        "transaction.id": "id",
+        "transaction.status": "status",
+        "transaction.amount_in_cents": "amount_in_cents",
+    }
+
+    def _calcular_checksum(self, data: dict, properties: list) -> str:
+        valores = "".join(str(data[self.PROPIEDADES_A_CAMPOS.get(campo, campo)]) for campo in properties)
+        cadena = f"{valores}{WOMPI_EVENTS_SECRET}"
+        return hashlib.sha256(cadena.encode("utf-8")).hexdigest()
+
+    def procesar_webhook(self, body: dict) -> dict:
+        ahora = datetime.now(timezone.utc)
+        data = body.get("data", {})
+        signature = body.get("signature", {})
+
+        checksum_recibido = signature.get("checksum", "")
+        checksum_esperado = self._calcular_checksum(data, signature.get("properties", []))
+
+        if checksum_recibido != checksum_esperado:
+            raise HTTPException(status_code=401, detail={
+                "success": False, "statusCode": 401,
+                "message": "Firma del webhook inválida",
+                "error": {"error_code": "INVALID_WEBHOOK_SIGNATURE",
+                          "details": "El checksum recibido no coincide con el esperado. La notificación fue descartada.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        referencia = data.get("reference")
+        pago = self.pago_repo.buscar_por_referencia(referencia)
+        if not pago:
+            raise HTTPException(status_code=404, detail={
+                "success": False, "statusCode": 404,
+                "message": "Pago no encontrado",
+                "error": {"error_code": "PAYMENT_NOT_FOUND",
+                          "details": f"No existe un pago con la referencia {referencia}.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        if data.get("amount_in_cents") != pago.monto_en_centavos:
+            raise HTTPException(status_code=401, detail={
+                "success": False, "statusCode": 401,
+                "message": "Firma del webhook inválida",
+                "error": {"error_code": "INVALID_WEBHOOK_SIGNATURE",
+                          "details": "El amount_in_cents recibido no coincide con el monto registrado para este pago.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        nuevo_estado = data.get("status")
+        estado_pedido_actual = pago.pedido.estado
+
+        # Idempotencia: si el pago ya está en ese estado, no duplicar acciones
+        if pago.estado_transaccion == nuevo_estado:
+            return {
+                "success": True,
+                "statusCode": 200,
+                "message": "Webhook procesado correctamente.",
+                "data": {
+                    "pedidoId": str(pago.pedido_id),
+                    "idTransaccionWompi": pago.id_transaccion_wompi,
+                    "estadoTransaccion": pago.estado_transaccion,
+                    "estadoPedidoActualizado": estado_pedido_actual,
+                    "fechaProcesamiento": ahora.isoformat(),
+                }
+            }
+
+        pago = self.pago_repo.actualizar_desde_webhook(
+            pago,
+            estado_transaccion=nuevo_estado,
+            id_transaccion_wompi=data.get("id"),
+            metodo_pago=data.get("payment_method_type"),
+        )
+
+        estado_pedido_actualizado = pago.pedido.estado
+        if nuevo_estado == "APPROVED":
+            pedido = self.pedido_repo.buscar_por_id(pago.pedido_id)
+            pedido_actualizado = self.pedido_repo.actualizar_estado(pedido, "pagado")
+            estado_pedido_actualizado = pedido_actualizado.estado
+
+        return {
+            "success": True,
+            "statusCode": 200,
+            "message": "Webhook procesado correctamente. Estado del pedido actualizado." if nuevo_estado == "APPROVED" else "Webhook procesado correctamente.",
+            "data": {
+                "pedidoId": str(pago.pedido_id),
+                "idTransaccionWompi": pago.id_transaccion_wompi,
+                "estadoTransaccion": pago.estado_transaccion,
+                "estadoPedidoActualizado": estado_pedido_actualizado,
+                "fechaProcesamiento": ahora.isoformat(),
+            }
+        }
 
     def _serializar_pago(self, pago: Pago, mensaje: str) -> dict:
         return {


### PR DESCRIPTION
Agrega el endpoint publico POST /pagos/webhook que valida la firma (checksum SHA256 con WOMPI_EVENTS_SECRET), verifica que amount_in_cents coincida con el monto registrado, busca el pago por referencia_interna y actualiza estado_transaccion, id_transaccion_wompi y metodo_pago. Si el estado es APPROVED, cambia el pedido a pagado; si es DECLINED, VOIDED o ERROR, el pedido permanece pendiente. El procesamiento es idempotente ante notificaciones duplicadas. Agrega placeholders de Wompi y Factus en .env.example.