### PR TITLE
feat: implementar HU-ENV-02 consulta de envios por id, pedido y lista…

### DIFF
--- a/app/api/envios/envios.api.py
+++ b/app/api/envios/envios.api.py
@@ -5,6 +5,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+from uuid import UUID
 import importlib.util, os
 
 from app.core.database import get_db
@@ -39,7 +40,7 @@ def _requerir_administrador(usuario_actual):
             "success": False, "statusCode": 403,
             "message": "Acceso denegado",
             "error": {"error_code": "FORBIDDEN",
-                      "details": "Solo un administrador puede registrar envíos."}
+                      "details": "Solo un administrador puede acceder a este recurso."}
         })
 
 
@@ -59,3 +60,33 @@ def registrar_envio(
         empresa_transporte=body.empresaTransporte,
         fecha_despacho=body.fechaDespacho,
     )
+
+
+@router.get("")
+def listar_envios(
+    db: Session = Depends(get_db),
+    usuario_actual = Depends(get_usuario_actual)
+):
+    _requerir_administrador(usuario_actual)
+    servicio = EnvioService(db)
+    return servicio.listar_envios()
+
+
+@router.get("/pedido/{pedido_id}")
+def consultar_envio_por_pedido(
+    pedido_id: UUID,
+    db: Session = Depends(get_db),
+    usuario_actual = Depends(get_usuario_actual)
+):
+    servicio = EnvioService(db)
+    return servicio.consultar_por_pedido_id(pedido_id, usuario_actual.id, usuario_actual.rol)
+
+
+@router.get("/{envio_id}")
+def consultar_envio_por_id(
+    envio_id: UUID,
+    db: Session = Depends(get_db),
+    usuario_actual = Depends(get_usuario_actual)
+):
+    servicio = EnvioService(db)
+    return servicio.consultar_por_id(envio_id, usuario_actual.id, usuario_actual.rol)

--- a/app/repositories/envios/envios.repositori.py
+++ b/app/repositories/envios/envios.repositori.py
@@ -22,3 +22,6 @@ class EnvioRepositorio:
 
     def buscar_por_pedido_id(self, pedido_id) -> Envio:
         return self.db.query(Envio).filter(Envio.pedido_id == pedido_id).first()
+
+    def listar_todos(self) -> list[Envio]:
+        return self.db.query(Envio).all()

--- a/app/services/envios/envios.services.py
+++ b/app/services/envios/envios.services.py
@@ -106,6 +106,68 @@ class EnvioService:
 
         return self._serializar_envio(envio, "Envío registrado correctamente", 201)
 
+    def listar_envios(self) -> dict:
+        envios = self.envio_repo.listar_todos()
+        return {
+            "success": True,
+            "statusCode": 200,
+            "message": "Envíos obtenidos correctamente",
+            "data": [
+                {
+                    "envioId": str(envio.id),
+                    "pedidoId": str(envio.pedido_id),
+                    "estado": envio.estado,
+                    "empresaTransporte": envio.empresa_transporte,
+                    "fechaDespacho": envio.fecha_despacho.isoformat(),
+                }
+                for envio in envios
+            ]
+        }
+
+    def consultar_por_id(self, envio_id, usuario_id, rol) -> dict:
+        ahora = datetime.now(timezone.utc)
+
+        envio = self.envio_repo.buscar_por_id(envio_id)
+        if not envio:
+            raise HTTPException(status_code=404, detail={
+                "success": False, "statusCode": 404,
+                "message": "Envío no encontrado",
+                "error": {"error_code": "SHIPMENT_NOT_FOUND",
+                          "details": "No existe un envío con el ID o pedido proporcionado.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        self._verificar_permiso(envio, usuario_id, rol, ahora)
+
+        return self._serializar_envio(envio, "Envío encontrado", 200)
+
+    def consultar_por_pedido_id(self, pedido_id, usuario_id, rol) -> dict:
+        ahora = datetime.now(timezone.utc)
+
+        envio = self.envio_repo.buscar_por_pedido_id(pedido_id)
+        if not envio:
+            raise HTTPException(status_code=404, detail={
+                "success": False, "statusCode": 404,
+                "message": "Envío no encontrado",
+                "error": {"error_code": "SHIPMENT_NOT_FOUND",
+                          "details": "No existe un envío con el ID o pedido proporcionado.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        self._verificar_permiso(envio, usuario_id, rol, ahora)
+
+        return self._serializar_envio(envio, "Envío encontrado", 200)
+
+    def _verificar_permiso(self, envio: Envio, usuario_id, rol, ahora) -> None:
+        if rol != "administrador" and envio.usuario_id != usuario_id:
+            raise HTTPException(status_code=403, detail={
+                "success": False, "statusCode": 403,
+                "message": "Acceso denegado",
+                "error": {"error_code": "FORBIDDEN",
+                          "details": "No tiene permisos para consultar este envío.",
+                          "timestamp": ahora.isoformat()}
+            })
+
     def _serializar_envio(self, envio: Envio, mensaje: str, status_code: int) -> dict:
         return {
             "success": True,


### PR DESCRIPTION
…do general

- GET /api/v1/envios (solo administrador): lista todos los envios, data: [] si no hay registros
- GET /api/v1/envios/{id}: detalle completo del envio, 404 SHIPMENT_NOT_FOUND si no existe
- GET /api/v1/envios/pedido/{idPedido}: detalle del envio asociado al pedido
- Control de acceso por rol: cliente solo consulta sus propios envios (403 FORBIDDEN), administrador sin restriccion
- Agrega listar_todos al EnvioRepositorio