### PR TITLE
feat: implementar HU-ENV-03 gestion del ciclo de vida del envio

### DIFF
--- a/app/api/envios/envios.api.py
+++ b/app/api/envios/envios.api.py
@@ -23,6 +23,7 @@ _spec_sch = importlib.util.spec_from_file_location("envios_schemas", _path_sch)
 _mod_sch  = importlib.util.module_from_spec(_spec_sch)
 _spec_sch.loader.exec_module(_mod_sch)
 EnvioEntrada = _mod_sch.EnvioEntrada
+ActualizarEstadoEnvioEntrada = _mod_sch.ActualizarEstadoEnvioEntrada
 
 # Cargar servicio
 _path_svc = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "services", "envios", "envios.services.py"))
@@ -90,3 +91,15 @@ def consultar_envio_por_id(
 ):
     servicio = EnvioService(db)
     return servicio.consultar_por_id(envio_id, usuario_actual.id, usuario_actual.rol)
+
+
+@router.patch("/{envio_id}")
+def actualizar_estado_envio(
+    envio_id: UUID,
+    body: ActualizarEstadoEnvioEntrada,
+    db: Session = Depends(get_db),
+    usuario_actual = Depends(get_usuario_actual)
+):
+    _requerir_administrador(usuario_actual)
+    servicio = EnvioService(db)
+    return servicio.actualizar_estado_envio(envio_id, body.estado)

--- a/app/domain/envios/envios.schemas.py
+++ b/app/domain/envios/envios.schemas.py
@@ -21,6 +21,10 @@ class EnvioEntrada(BaseModel):
     fechaDespacho:     date
 
 
+class ActualizarEstadoEnvioEntrada(BaseModel):
+    estado: str
+
+
 class EnvioSalida(BaseModel):
     id:                  UUID4
     pedido_id:           UUID4

--- a/app/repositories/envios/envios.repositori.py
+++ b/app/repositories/envios/envios.repositori.py
@@ -4,6 +4,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 from sqlalchemy.orm import Session
+from datetime import datetime, timezone
 from app.domain.envios import Envio
 
 
@@ -25,3 +26,10 @@ class EnvioRepositorio:
 
     def listar_todos(self) -> list[Envio]:
         return self.db.query(Envio).all()
+
+    def actualizar_estado(self, envio: Envio, nuevo_estado: str) -> Envio:
+        envio.estado = nuevo_estado
+        envio.fecha_actualizacion = datetime.now(timezone.utc)
+        self.db.flush()
+        self.db.refresh(envio)
+        return envio

--- a/app/services/envios/envios.services.py
+++ b/app/services/envios/envios.services.py
@@ -41,6 +41,9 @@ TARIFAS_ENVIO_POR_CIUDAD = {
 }
 TARIFA_ENVIO_DEFECTO = 15000
 
+# Flujo secuencial y unidireccional de estados del envío.
+FLUJO_ESTADOS_ENVIO = ("en_preparacion", "despachado", "en_transito", "entregado")
+
 
 class EnvioService:
     def __init__(self, db: Session):
@@ -167,6 +170,66 @@ class EnvioService:
                           "details": "No tiene permisos para consultar este envío.",
                           "timestamp": ahora.isoformat()}
             })
+
+    def actualizar_estado_envio(self, envio_id, nuevo_estado: str) -> dict:
+        ahora = datetime.now(timezone.utc)
+
+        envio = self.envio_repo.buscar_por_id(envio_id)
+        if not envio:
+            raise HTTPException(status_code=404, detail={
+                "success": False, "statusCode": 404,
+                "message": "Envío no encontrado",
+                "error": {"error_code": "SHIPMENT_NOT_FOUND",
+                          "details": "No existe un envío con el ID proporcionado.",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        if nuevo_estado not in FLUJO_ESTADOS_ENVIO:
+            raise HTTPException(status_code=400, detail={
+                "success": False, "statusCode": 400,
+                "message": "El estado proporcionado no es válido",
+                "error": {"error_code": "INVALID_SHIPMENT_STATUS",
+                          "details": f"Los estados válidos son: {', '.join(FLUJO_ESTADOS_ENVIO)}",
+                          "timestamp": ahora.isoformat()}
+            })
+
+        indice_actual = FLUJO_ESTADOS_ENVIO.index(envio.estado)
+        indice_nuevo  = FLUJO_ESTADOS_ENVIO.index(nuevo_estado)
+
+        if indice_nuevo != indice_actual + 1:
+            if indice_actual == len(FLUJO_ESTADOS_ENVIO) - 1:
+                detalle = f"El envío está en estado '{envio.estado}'. No existe un siguiente estado válido."
+            else:
+                siguiente = FLUJO_ESTADOS_ENVIO[indice_actual + 1]
+                detalle = f"El envío está en estado '{envio.estado}'. El único siguiente estado válido es '{siguiente}'."
+            raise HTTPException(status_code=409, detail={
+                "success": False, "statusCode": 409,
+                "message": "Transición de estado no permitida",
+                "error": {"error_code": "INVALID_STATE_TRANSITION",
+                          "details": detalle,
+                          "timestamp": ahora.isoformat()}
+            })
+
+        envio = self.envio_repo.actualizar_estado(envio, nuevo_estado)
+
+        if nuevo_estado == "entregado":
+            pedido = self.pedido_repo.buscar_por_id(envio.pedido_id)
+            pedido.estado = "entregado"
+            pedido.fecha_actualizacion = ahora
+
+        self.db.commit()
+        self.db.refresh(envio)
+
+        return {
+            "success": True,
+            "statusCode": 200,
+            "message": "Estado del envío actualizado correctamente",
+            "data": {
+                "envioId": str(envio.id),
+                "estado": envio.estado,
+                "fechaActualizacion": envio.fecha_actualizacion.isoformat(),
+            }
+        }
 
     def _serializar_envio(self, envio: Envio, mensaje: str, status_code: int) -> dict:
         return {


### PR DESCRIPTION
- PATCH /api/v1/envios/{id} (solo administrador): actualiza el estado del envio
- Valida flujo secuencial y unidireccional: en_preparacion -> despachado -> en_transito -> entregado
- 400 INVALID_SHIPMENT_STATUS si el estado no es valido
- 409 INVALID_STATE_TRANSITION si se intenta saltar o retroceder estados
- 404 SHIPMENT_NOT_FOUND si el envio no existe
- Al llegar a entregado, actualiza tambien el pedido asociado a entregado en la misma transaccion
- Agrega actualizar_estado al EnvioRepositorio y ActualizarEstadoEnvioEntrada al schema